### PR TITLE
feat: add std::error::Error impl for webview2-com::Error

### DIFF
--- a/crates/webview2-com/src/lib.rs
+++ b/crates/webview2-com/src/lib.rs
@@ -27,6 +27,8 @@ pub enum Error {
     SendError,
 }
 
+impl std::error::Error for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{self:?}")


### PR DESCRIPTION
This allows `webview2-com::Result` to be compatible with `anyhow::Result`, making it easy to handle `webview2-com::Error` using anyhow's helper methods.